### PR TITLE
baseimage, baseimage-wheezy: quote env vars in /etc/profile.d/00docker-env.sh by `export -p`

### DIFF
--- a/baseimage-wheezy/build/opt/init-wrapper/pre-init.d/10-save-env
+++ b/baseimage-wheezy/build/opt/init-wrapper/pre-init.d/10-save-env
@@ -3,27 +3,26 @@
 ##
 ## save environment variables to /etc/profile.d/docker-env.sh
 ##
-env | sort | sed \
-  -e '/^HOME=/d' \
-  -e '/^HOSTNAME=/d' \
-  -e '/^PATH=/d' \
-  -e '/^PWD=/d' \
-  -e '/^TERM=/d' \
-  -e '/^USER_PASSWORD=/d' \
-  -e '/^USER_SSH_KEY_URI=/d' \
-  -e '/^ROOT_PASSWORD=/d' \
-  -e '/^ROOT_SSH_KEY_URI=/d' \
-  -e '/^CUSTOM_GROUP=/d' \
-  -e '/^CUSTOM_GROUP_GID=/d' \
-  -e '/^CUSTOM_USER=/d' \
-  -e '/^CUSTOM_USER_UID=/d' \
-  -e '/^CUSTOM_USER_GECOS=/d' \
-  -e '/^CUSTOM_USER_SHELL=/d' \
-  -e '/^CUSTOM_USER_PASSWORD=/d' \
-  -e '/^CUSTOM_USER_SSH_KEY_URI=/d' \
-  -e '/^APT_LINE=/d' \
-  -e '/^APT_UPDATE=/d' \
-  -e 's/^/export /' \
+export -p | sed \
+  -e '/^export HOME=/d' \
+  -e '/^export HOSTNAME=/d' \
+  -e '/^export PATH=/d' \
+  -e '/^export PWD=/d' \
+  -e '/^export TERM=/d' \
+  -e '/^export USER_PASSWORD=/d' \
+  -e '/^export USER_SSH_KEY_URI=/d' \
+  -e '/^export ROOT_PASSWORD=/d' \
+  -e '/^export ROOT_SSH_KEY_URI=/d' \
+  -e '/^export CUSTOM_GROUP=/d' \
+  -e '/^export CUSTOM_GROUP_GID=/d' \
+  -e '/^export CUSTOM_USER=/d' \
+  -e '/^export CUSTOM_USER_UID=/d' \
+  -e '/^export CUSTOM_USER_GECOS=/d' \
+  -e '/^export CUSTOM_USER_SHELL=/d' \
+  -e '/^export CUSTOM_USER_PASSWORD=/d' \
+  -e '/^export CUSTOM_USER_SSH_KEY_URI=/d' \
+  -e '/^export APT_LINE=/d' \
+  -e '/^export APT_UPDATE=/d' \
 > /etc/profile.d/00docker-env.sh
 
 if dpkg-query -s etckeeper 1>/dev/null 2>/dev/null; then

--- a/baseimage-wheezy/build/opt/init-wrapper/pre-init.d/10-save-env
+++ b/baseimage-wheezy/build/opt/init-wrapper/pre-init.d/10-save-env
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 ##
-## save environment variables to /etc/profile.d/docker-env.sh
+## save environment variables to /etc/profile.d/00docker-env.sh
 ##
 export -p | sed \
   -e '/^export HOME=/d' \

--- a/baseimage/build/opt/init-wrapper/pre-init.d/10-save-env
+++ b/baseimage/build/opt/init-wrapper/pre-init.d/10-save-env
@@ -3,27 +3,26 @@
 ##
 ## save environment variables to /etc/profile.d/docker-env.sh
 ##
-env | sort | sed \
-  -e '/^HOME=/d' \
-  -e '/^HOSTNAME=/d' \
-  -e '/^PATH=/d' \
-  -e '/^PWD=/d' \
-  -e '/^TERM=/d' \
-  -e '/^USER_PASSWORD=/d' \
-  -e '/^USER_SSH_KEY_URI=/d' \
-  -e '/^ROOT_PASSWORD=/d' \
-  -e '/^ROOT_SSH_KEY_URI=/d' \
-  -e '/^CUSTOM_GROUP=/d' \
-  -e '/^CUSTOM_GROUP_GID=/d' \
-  -e '/^CUSTOM_USER=/d' \
-  -e '/^CUSTOM_USER_UID=/d' \
-  -e '/^CUSTOM_USER_GECOS=/d' \
-  -e '/^CUSTOM_USER_SHELL=/d' \
-  -e '/^CUSTOM_USER_PASSWORD=/d' \
-  -e '/^CUSTOM_USER_SSH_KEY_URI=/d' \
-  -e '/^APT_LINE=/d' \
-  -e '/^APT_UPDATE=/d' \
-  -e 's/^/export /' \
+export -p | sed \
+  -e '/^export HOME=/d' \
+  -e '/^export HOSTNAME=/d' \
+  -e '/^export PATH=/d' \
+  -e '/^export PWD=/d' \
+  -e '/^export TERM=/d' \
+  -e '/^export USER_PASSWORD=/d' \
+  -e '/^export USER_SSH_KEY_URI=/d' \
+  -e '/^export ROOT_PASSWORD=/d' \
+  -e '/^export ROOT_SSH_KEY_URI=/d' \
+  -e '/^export CUSTOM_GROUP=/d' \
+  -e '/^export CUSTOM_GROUP_GID=/d' \
+  -e '/^export CUSTOM_USER=/d' \
+  -e '/^export CUSTOM_USER_UID=/d' \
+  -e '/^export CUSTOM_USER_GECOS=/d' \
+  -e '/^export CUSTOM_USER_SHELL=/d' \
+  -e '/^export CUSTOM_USER_PASSWORD=/d' \
+  -e '/^export CUSTOM_USER_SSH_KEY_URI=/d' \
+  -e '/^export APT_LINE=/d' \
+  -e '/^export APT_UPDATE=/d' \
 > /etc/profile.d/00docker-env.sh
 
 if dpkg-query -s etckeeper 1>/dev/null 2>/dev/null; then

--- a/baseimage/build/opt/init-wrapper/pre-init.d/10-save-env
+++ b/baseimage/build/opt/init-wrapper/pre-init.d/10-save-env
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 ##
-## save environment variables to /etc/profile.d/docker-env.sh
+## save environment variables to /etc/profile.d/00docker-env.sh
 ##
 export -p | sed \
   -e '/^export HOME=/d' \


### PR DESCRIPTION
before this commit:

```
% docker run -e FOO="a \"b\" 'c'" -d --name before minimum2scp/baseimage:latest
7aefa5676ed5cd63e3db656a80d6c0a7025813691c8796fe805d85666f669d58
% docker exec before cat /etc/profile.d/00docker-env.sh
export FOO=a "b" 'c'
% docker exec before sh -c 'echo $FOO'
a "b" 'c'
% docker exec before sh -lc 'echo $FOO'
a
```

after this commit:

```
% docker run -e FOO="a \"b\" 'c'" -d --name after minimum2scp/baseimage:next
0e7a6f32c742b592d1a8261b889ca043f15bd69c1f2a91ae93b4ad4b00824795
% docker exec after cat /etc/profile.d/00docker-env.sh
export FOO='a "b" '"'"'c'"'"
% docker exec after sh -c 'echo $FOO'
a "b" 'c'
% docker exec after sh -lc 'echo $FOO'
a "b" 'c'
```