### PR TITLE
tdiary: use Ruby 2.2.1

### DIFF
--- a/tdiary/build/user-scripts/setup-tdiary.sh
+++ b/tdiary/build/user-scripts/setup-tdiary.sh
@@ -34,7 +34,7 @@ install -m 644 -p /build/$GHQ_ROOT/github.com/tdiary/tdiary-core/Gemfile.local $
 ## run bundle install
 cd $GHQ_ROOT/github.com/tdiary/tdiary-core
 mkdir -p vendor/bundle
-bash -l -c "cd ~; rbenv local 2.2.0"
+bash -l -c "cd ~; rbenv local 2.2.1"
 bash -l -c "bundle install --path vendor/bundle"
 
 


### PR DESCRIPTION
fix build error
```
+ bash -l -c cd ~; rbenv local 2.2.0

rbenv: version `2.2.0' not installed
```