### PR TITLE
sphinx: fixed build error while `pip install sphinxjp.themecore ...`

### DIFF
--- a/sphinx/build/scripts/01-setup
+++ b/sphinx/build/scripts/01-setup
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 packages="python-sphinx"
 packages="$packages python-sphinxcontrib.blockdiag python-sphinxcontrib.actdiag"
 packages="$packages python-sphinxcontrib.seqdiag python-sphinxcontrib.nwdiag"
-packages="$packages python-pip python-pil"
+packages="$packages python-setuptools python-pip python-pil"
 packages="$packages make"
 packages="$packages fonts-ipafont-gothic fonts-ipafont-mincho"
 


### PR DESCRIPTION
```
+ pip install sphinxjp.themecore sphinxjp.themes.sphinxjp sphinx_rtd_theme
Collecting sphinxjp.themecore
  Downloading sphinxjp.themecore-0.2.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-mMoOEL/sphinxjp.themecore
```