### PR TITLE
Revert "http_proxy support for apt on docker build"

### DIFF
--- a/apt-cacher-ng/build/scripts/00-update
+++ b/apt-cacher-ng/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/apt-cacher-ng/build/scripts/99-cleanup
+++ b/apt-cacher-ng/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/baseimage-jessie/build/scripts/00-apt-update
+++ b/baseimage-jessie/build/scripts/00-apt-update
@@ -6,15 +6,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 install -m 644 -o root -g root -p /tmp/build/baseimage-jessie/etc/apt/sources.list /etc/apt/sources.list
 
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
 apt-get update
 apt-get dist-upgrade -y --fix-missing --fix-broken
 

--- a/baseimage-jessie/build/scripts/99-cleanup
+++ b/baseimage-jessie/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/baseimage-wheezy/build/scripts/00-apt-update
+++ b/baseimage-wheezy/build/scripts/00-apt-update
@@ -6,15 +6,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 install -m 644 -o root -g root -p /tmp/build/baseimage-wheezy/etc/apt/sources.list /etc/apt/sources.list
 
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
 apt-get update
 apt-get dist-upgrade -y --fix-missing --fix-broken
 

--- a/baseimage-wheezy/build/scripts/99-cleanup
+++ b/baseimage-wheezy/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/baseimage/build/scripts/00-apt-update
+++ b/baseimage/build/scripts/00-apt-update
@@ -6,15 +6,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 install -m 644 -o root -g root -p /tmp/build/baseimage/etc/apt/sources.list /etc/apt/sources.list
 
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
 apt-get update
 apt-get dist-upgrade -y --fix-missing --fix-broken
 

--- a/baseimage/build/scripts/99-cleanup
+++ b/baseimage/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/es-kibana/build/scripts/00-update
+++ b/es-kibana/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/es-kibana/build/scripts/99-cleanup
+++ b/es-kibana/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/fluentd-ui/build/scripts/00-update
+++ b/fluentd-ui/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/fluentd-ui/build/scripts/99-cleanup
+++ b/fluentd-ui/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/geminabox/build/scripts/00-update
+++ b/geminabox/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/geminabox/build/scripts/99-cleanup
+++ b/geminabox/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/hubot/build/scripts/00-update
+++ b/hubot/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/hubot/build/scripts/99-cleanup
+++ b/hubot/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/mruby/build/scripts/00-update
+++ b/mruby/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/mruby/build/scripts/99-cleanup
+++ b/mruby/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/nodejs/build/scripts/00-update
+++ b/nodejs/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/nodejs/build/scripts/99-cleanup
+++ b/nodejs/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/norikra/build/scripts/00-update
+++ b/norikra/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/norikra/build/scripts/99-cleanup
+++ b/norikra/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/rails4/build/scripts/00-update
+++ b/rails4/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/rails4/build/scripts/99-cleanup
+++ b/rails4/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/ruby-full/build/scripts/00-update
+++ b/ruby-full/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/ruby-full/build/scripts/99-cleanup
+++ b/ruby-full/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/ruby-jessie/build/scripts/00-update
+++ b/ruby-jessie/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/ruby-jessie/build/scripts/99-cleanup
+++ b/ruby-jessie/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/ruby-wheezy/build/scripts/00-update
+++ b/ruby-wheezy/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/ruby-wheezy/build/scripts/99-cleanup
+++ b/ruby-wheezy/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/ruby/build/scripts/00-update
+++ b/ruby/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/ruby/build/scripts/99-cleanup
+++ b/ruby/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/sphinx/build/scripts/00-update
+++ b/sphinx/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/sphinx/build/scripts/99-cleanup
+++ b/sphinx/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/squid/build/scripts/00-update
+++ b/squid/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/squid/build/scripts/99-cleanup
+++ b/squid/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/systemd/build/scripts/00-update
+++ b/systemd/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/systemd/build/scripts/99-cleanup
+++ b/systemd/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/tdiary/build/scripts/00-update
+++ b/tdiary/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/tdiary/build/scripts/99-cleanup
+++ b/tdiary/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email

--- a/template/build/scripts/00-update
+++ b/template/build/scripts/00-update
@@ -10,18 +10,6 @@ export DEBIAN_FRONTEND=noninteractive
 git config --global user.email "root@`hostname`"
 
 ##
-## configure http_proxy for apt
-##
-if [ "${http_proxy}" ]; then
-  echo "Acquire::http::proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Enabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## upgrade installed packages
 ##
 apt-get update

--- a/template/build/scripts/99-cleanup
+++ b/template/build/scripts/99-cleanup
@@ -5,18 +5,6 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ##
-## unset http_proxy
-##
-if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then
-  rm /etc/apt/apt.conf.d/proxy.conf
-  if [ -x /usr/bin/etckeeper ]; then
-    if etckeeper unclean; then
-      etckeeper commit "Disabled http_proxy for apt"
-    fi
-  fi
-fi
-
-##
 ## unset user.email (etckeeper)
 ##
 git config --global --unset user.email


### PR DESCRIPTION
apt-get uses `http_proxy` environment variable when Acquire::http::proxy is not set,
so no need to set `Acqire::http::proxy` on building image.
