### PR TITLE
Added rake into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'serverspec'
 gem 'specinfra'
 gem 'docker-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -57,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   docker-api
   pry
+  rake
   sequel
   serverspec
   specinfra


### PR DESCRIPTION
```
/usr/lib/ruby/vendor_ruby/bundler/rubygems_integration.rb:304:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
	from /home/tsuyoshi/go/src/github.com/minimum2scp/dockerfiles/vendor/bundle/ruby/2.3.0/bin/rake:22:in `<main>'
rake aborted!
```