### PR TITLE
ruby-full: do not install ruby2.2

### DIFF
--- a/ruby-full/build/scripts/01-setup
+++ b/ruby-full/build/scripts/01-setup
@@ -4,8 +4,3 @@ set -e
 set -x
 export DEBIAN_FRONTEND=noninteractive
 
-##
-## install Ruby 2.2 by deb package
-##
-apt-get install -y --no-install-recommends ruby2.2 ruby2.2-dev
-


### PR DESCRIPTION
Fixed build problem:

```
+ apt-get install -y --no-install-recommends ruby2.2 ruby2.2-dev
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package ruby2.2
E: Couldn't find any package by glob 'ruby2.2'
E: Couldn't find any package by regex 'ruby2.2'
E: Unable to locate package ruby2.2-dev
E: Couldn't find any package by glob 'ruby2.2-dev'
E: Couldn't find any package by regex 'ruby2.2-dev'
```