### PR TITLE
rails4: Do not install rails 4.x gem for ruby 2.4.0-preview2

### DIFF
--- a/rails4/build/scripts/01-setup
+++ b/rails4/build/scripts/01-setup
@@ -13,7 +13,7 @@ packages="$packages postgresql-client libpq-dev"
 apt-get install --install-recommends -y ${packages}
 
 ## install rails (by gem)
-for v in $(bash -lc "rbenv versions --bare --skip-aliases"); do
+for v in $(bash -lc "rbenv versions --bare --skip-aliases" | grep -v '2.4.0-preview2'); do
   bash -lc "RBENV_VERSION=${v} gem install -N rails --version '~> 4.0'"
 done
 bash -lc "rbenv rehash"


### PR DESCRIPTION
https://hub.docker.com/r/minimum2scp/rails4/builds/b6fnxiusdcrgcuq3bkrtmu7/