### PR TITLE
rails4: Do not install rails 4.x gem for ruby 2.4.0-rc1

### DIFF
--- a/rails4/build/scripts/01-setup
+++ b/rails4/build/scripts/01-setup
@@ -13,7 +13,7 @@ packages="$packages postgresql-client libpq-dev"
 apt-get install --install-recommends -y ${packages}
 
 ## install rails (by gem)
-for v in $(bash -lc "rbenv versions --bare --skip-aliases" | grep -v '2.4.0-preview3'); do
+for v in $(bash -lc "rbenv versions --bare --skip-aliases" | grep -v '2.4.0-rc1'); do
   bash -lc "RBENV_VERSION=${v} gem install -N rails --version '~> 4.0'"
 done
 bash -lc "rbenv rehash"


### PR DESCRIPTION
```
+ bash -lc RBENV_VERSION=2.4.0-rc1 gem install -N rails --version '~> 4.0'
(snip)
Building native extensions.  This could take a while...

ERROR:  Error installing rails:
	ERROR: Failed to build gem native extension.

    current directory: /opt/rbenv/versions/2.4.0-rc1/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
/opt/rbenv/versions/2.4.0-rc1/bin/ruby -r ./siteconf20161214-6695-1w3bidu.rb extconf.rb
creating Makefile

current directory: /opt/rbenv/versions/2.4.0-rc1/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /opt/rbenv/versions/2.4.0-rc1/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c: In function 'generate_json':
generator.c:861:25: error: 'rb_cFixnum' undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^~~~~~~~~~
generator.c:861:25: note: each undeclared identifier is reported only once for each function it appears in
generator.c:863:25: error: 'rb_cBignum' undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^~~~~~~~~~
generator.c: At top level:
cc1: warning: unrecognized command line option '-Wno-self-assign'
cc1: warning: unrecognized command line option '-Wno-constant-logical-operand'
cc1: warning: unrecognized command line option '-Wno-parentheses-equality'
Makefile:241: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /opt/rbenv/versions/2.4.0-rc1/lib/ruby/gems/2.4.0/gems/json-1.8.3 for inspection.
Results logged to /opt/rbenv/versions/2.4.0-rc1/lib/ruby/gems/2.4.0/extensions/x86_64-linux/2.4.0-static/json-1.8.3/gem_make.out
```