### PR TITLE
fluentd-ui: fixed build error (installed gnupg, dirmngr packages)

### DIFF
--- a/fluentd-ui/build/scripts/01-setup
+++ b/fluentd-ui/build/scripts/01-setup
@@ -5,7 +5,7 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 
 ## install build-dependencies
-apt-get install --no-install-recommends -y libcurl4-openssl-dev
+apt-get install --no-install-recommends -y libcurl4-openssl-dev gnupg dirmngr
 
 ## install td-agent
 curl -L https://td-toolbelt.herokuapp.com/sh/install-debian-jessie-td-agent2.sh | sh


### PR DESCRIPTION
```
+ curl -L https://td-toolbelt.herokuapp.com/sh/install-debian-jessie-td-agent2.sh
+ sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   551  100   551    0     0    232      0  0:00:02  0:00:02 --:--:--   232
This script requires superuser access to install apt packages.
You will be prompted for your password by sudo.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
100  3157  100  3157    0     0  19062      0 --:--:-- --:--:-- --:--:-- 19133
(23) Failed writing body
```