### PR TITLE
squid: minor typo correction in readme

### DIFF
--- a/squid/README.md
+++ b/squid/README.md
@@ -12,7 +12,7 @@ docker run -d -p 3128:3128 minimum2scp/squid
 and then use from localhost:
 
 ```
-export http_proxy=htpt://127.0.0.1:3128
+export http_proxy=http://127.0.0.1:3128
 curl http://example.com/
 ```
 


### PR DESCRIPTION
Fix `htpt://` and replace with `http://` in proxy environment variable example.