### PR TITLE
[WIP] Build docker image with apt-cacher-ng

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,27 @@ jobs:
 
       - run: digdag --version
       - run: digdag check
-      - run: digdag run ci-build.dig --rerun
+
+      - run:
+          name: Run apt-cacher-ng
+          command: |
+            set -x
+            docker run -d --name acng minimum2scp/apt-cacher-ng:latest
+
+      - run:
+          name: Check apt-cacher-ng
+          command: |
+            set -x
+            acng_uri=http://$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' acng):3142
+            echo "http_proxy=${acng_uri}"
+            docker run --rm --entrypoint=/bin/sh minimum2scp/apt-cacher-ng:latest -c "curl ${acng_uri}/acng-report.html"
+
+      - run:
+          name: Build images
+          command: |
+            set -x
+            acng_uri=http://$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' acng):3142
+            digdag run ci-build.dig -p acng_uri=${acng_uri} --rerun
 
       - run:
           name: Build rspec-runner image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,24 @@ jobs:
       - run: digdag --version
       - run: digdag check
 
+      - restore_cache:
+          keys:
+            - acng-cache-{{ .Branch }}
+            - acng-cache-master
+
       - run:
           name: Run apt-cacher-ng
           command: |
             set -x
             docker run -d --name acng minimum2scp/apt-cacher-ng:latest
+            if [ -d .circleci/cache/acng/apt-cacher-ng/ ]; then
+              docker exec -t acng service apt-cacher-ng stop
+              docker cp .circleci/cache/acng/apt-cacher-ng/ acng:/var/cache/apt-cacher-ng/
+              docker exec -t acng chown -R apt-cacher-ng:apt-cacher-ng /var/cache/apt-cacher-ng/
+              docker exec -t acng service apt-cacher-ng start
+            else
+              mkdir -p .circleci/cache/acng/
+            fi
 
       - run:
           name: Check apt-cacher-ng
@@ -73,6 +86,18 @@ jobs:
             set -x
             acng_uri=http://$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' acng):3142
             digdag run ci-build.dig -p acng_uri=${acng_uri} --rerun
+
+      - run:
+          name: Stop apt-cacher-ng
+          command: |
+            set -x
+            docker stop acng
+            docker cp acng:/var/cache/apt-cacher-ng/ .circleci/cache/acng/apt-cacher-ng/
+
+      - save_cache:
+          key: acng-cache-{{ .Branch }}-{{ epoch }}
+          paths:
+            - .circleci/cache/acng/
 
       - run:
           name: Build rspec-runner image

--- a/.circleci/tasks/build_flow.rb
+++ b/.circleci/tasks/build_flow.rb
@@ -17,7 +17,12 @@ class BuildFlow
   end
 
   def build_image
-    cmd = "docker build -t #{@image} #{@directory}"
+    http_proxy = Digdag.env.params['acng_uri']
+    if http_proxy
+      cmd = "docker build -t #{@image} --build-arg http_proxy=#{http_proxy} --build-arg https_proxy= #{@directory}"
+    else
+      cmd = "docker build -t #{@image} #{@directory}"
+    end
     puts "Started build #{@image} (#{cmd})"
     ret, d = run_command(cmd)
     if ret == 0

--- a/ruby-wheezy/build/scripts/01-setup
+++ b/ruby-wheezy/build/scripts/01-setup
@@ -12,6 +12,9 @@ packages="$packages build-essential autoconf bison ca-certificates libgdbm-dev l
 ## install packages
 apt-get install --no-install-recommends -y ${packages}
 
+## Workaround for `gem install` with apt-cacher-ng
+unset http_proxy https_proxy
+
 ## install bundler, pry by gem command
 gem install bundler --version 1.14.6
 gem install pry


### PR DESCRIPTION
TODO:

- Cleanup old cache (keep cache size small):`save_cache`, `restore_cache`, `docker cp` are slow
- Building images with apt-cacher-ng did not get so fast as I expected
