### PR TITLE
ruby, ruby-full: Fixed spec (ruby2.5 transition)

### DIFF
--- a/ruby-full/README.md
+++ b/ruby-full/README.md
@@ -7,7 +7,7 @@
 
  * based on minimum2scp/ruby (see https://github.com/minimum2scp/dockerfiles/tree/master/ruby)
  * ruby ruby ruby 2.2.9, ruby 2.3.6, ruby 2.4.3, ruby 2.5.0, ruby 2.6.0-preview1 is installed by rbenv
- * ruby 2.3.6 is installed by debian package
+ * ruby 2.5.0 is installed by debian package
 
 ## ssh login to container
 
@@ -61,7 +61,7 @@ rbenv gloabl (/opt/rbenv/version) is not defined, and some rubies are built.
   2.5.0
   2.6.0-preview1
 % docker run --rm -t minimum2scp/ruby-full:latest /bin/bash -l -c "ruby -v"
-ruby 2.3.6p384 (2017-12-14) [x86_64-linux-gnu]
+ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux-gnu]
 ```
 
 

--- a/spec/ruby-full/00base_spec.rb
+++ b/spec/ruby-full/00base_spec.rb
@@ -109,14 +109,14 @@ describe 'minimum2scp/ruby-full' do
       end
     end
 
-    %w[ruby2.3 ruby2.3-dev].each do |pkg|
+    %w[ruby2.5 ruby2.5-dev].each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end
     end
 
-    describe command('ruby2.3 -v') do
-      its(:stdout) { should include 'ruby 2.3.6p384 (2017-12-14) [x86_64-linux-gnu]' }
+    describe command('ruby2.5 -v') do
+      its(:stdout) { should include 'ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux-gnu]' }
     end
   end
 end

--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -43,11 +43,11 @@ describe 'minimum2scp/ruby' do
 
     describe file('/usr/bin/ruby') do
       it { should be_symlink }
-      it { should be_linked_to('ruby2.3') }
+      it { should be_linked_to('ruby2.5') }
     end
 
-    describe command('ruby2.3 -v') do
-      its(:stdout) { should include 'ruby 2.3.6p384 (2017-12-14) [x86_64-linux-gnu]' }
+    describe command('ruby2.5 -v') do
+      its(:stdout) { should include 'ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux-gnu]' }
     end
 
     describe file('/opt/rbenv') do


### PR DESCRIPTION
ruby-defaults 1:2.5.0
https://tracker.debian.org/news/937912
ruby2.5 2.5.0-6
https://tracker.debian.org/news/937877
transition: ruby2.5
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=888531
https://release.debian.org/transitions/html/ruby2.5.html