### PR TITLE
tdiary: fixed build error

### DIFF
--- a/tdiary/build/user-scripts/setup-tdiary.sh
+++ b/tdiary/build/user-scripts/setup-tdiary.sh
@@ -37,6 +37,10 @@ bash -l -c "bundle install --path vendor/bundle --jobs=4"
 ## add Gemfile.local
 install -m 644 -p /tmp/build/tdiary/$GHQ_ROOT/github.com/tdiary/tdiary-core/Gemfile.local $GHQ_ROOT/github.com/tdiary/tdiary-core/Gemfile.local
 
+## workaround to resolve conflict `Bundler could not find compatible versions for gem "faraday"`
+bash -l -c "bundle lock --update faraday"
+GIT_PAGER= git diff Gemfile.lock
+
 ## run bundle install again
 bash -l -c "bundle install"
 bash -l -c "bundle clean"


### PR DESCRIPTION
Workaround for build error:

```
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 0.14.0)

  In Gemfile:
    tdiary-contrib was resolved to 5.0.8, which depends on
      pushbullet_ruby was resolved to 1.1.1, which depends on
        faraday (~> 0.9.0)

    octokit was resolved to 4.8.0, which depends on
      sawyer (>= 0.5.3, ~> 0.8.0) was resolved to 0.8.1, which depends on
        faraday (< 1.0, ~> 0.8)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```