### PR TITLE
Workaround for building baseimage

### DIFF
--- a/baseimage/build/etc/apt/sources.list
+++ b/baseimage/build/etc/apt/sources.list
@@ -15,7 +15,7 @@
 ## testing
 ##
 
-#deb     http://deb.debian.org/debian/ testing main contrib non-free
+deb     http://deb.debian.org/debian/ testing main contrib non-free
 #deb-src http://deb.debian.org/debian/ testing main contrib non-free
 
 ##

--- a/baseimage/build/scripts/01-setup
+++ b/baseimage/build/scripts/01-setup
@@ -13,6 +13,7 @@ packages="$packages locales tzdata"
 packages="$packages localepurge"
 packages="$packages sysvinit-core systemd-sysv- systemd-"
 packages="$packages openssh-server rsyslog cron"
+packages="$packages libldap-2.4-2=2.4.45+dfsg-1 libldap-common=2.4.45+dfsg-1"
 
 ##
 ## install packages

--- a/spec/baseimage/00base_spec.rb
+++ b/spec/baseimage/00base_spec.rb
@@ -41,7 +41,7 @@ describe 'minimum2scp/baseimage' do
       its(:content) { should match apt_line_re[false, 'deb',     'http://deb.debian.org/debian/', 'stable-updates', 'main', 'contrib', 'non-free'] }
       its(:content) { should match apt_line_re[false, 'deb-src', 'http://deb.debian.org/debian/', 'stable-updates', 'main', 'contrib', 'non-free'] }
       ## testing
-      its(:content) { should match apt_line_re[false, 'deb',     'http://deb.debian.org/debian/', 'testing',        'main', 'contrib', 'non-free'] }
+      its(:content) { should match apt_line_re[true,  'deb',     'http://deb.debian.org/debian/', 'testing',        'main', 'contrib', 'non-free'] }
       its(:content) { should match apt_line_re[false, 'deb-src', 'http://deb.debian.org/debian/', 'testing',        'main', 'contrib', 'non-free'] }
       ## sid
       its(:content) { should match apt_line_re[true,  'deb',     'http://deb.debian.org/debian/', 'sid',            'main', 'contrib', 'non-free'] }


### PR DESCRIPTION
Building baseimage failed:

```console
% docker build --no-cache -t minimum2scp/baseimage:latest baseimage
Sending build context to Docker daemon  221.7kB
Step 1/7 : FROM minimum2scp/debian:latest
 ---> 38d941937d0b
Step 2/7 : MAINTAINER YAMADA Tsuyoshi tyamada@minimum2scp.org
 ---> Running in b2cad4391d32
Removing intermediate container b2cad4391d32
 ---> 525c960cb818
Step 3/7 : COPY build /tmp/build/baseimage
 ---> 9150b28f96fb
Step 4/7 : RUN run-parts --report --exit-on-error /tmp/build/baseimage/scripts && rm -rfv /tmp/build
 ---> Running in 2e9dcba6e139
...(snip)...
+ apt-get install -y --no-install-recommends --auto-remove --purge sudo adduser curl ca-certificates openssl git lv vim-tiny man-db whiptail zsh net-tools unzip etckeeper locales tzdata localepurge sysvinit-core systemd-sysv- systemd- openssh-server rsyslog cron
Reading package lists...
Building dependency tree...
Package 'systemd' is not installed, so not removed
Package 'systemd-sysv' is not installed, so not removed
adduser is already the newest version (3.117).
tzdata is already the newest version (2018e-1).
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 curl : Depends: libcurl3 (= 7.58.0-2) but it is not going to be installed
 git : Depends: libcurl3-gnutls (>= 7.16.2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
run-parts: /tmp/build/baseimage/scripts/01-setup exited with return code 100
The command '/bin/sh -c run-parts --report --exit-on-error /tmp/build/baseimage/scripts && rm -rfv /tmp/build' returned a non-zero code: 1
```

Further investigation:

```console
% docker run --rm -ti minimum2scp/debian:latest /bin/bash
Unable to find image 'minimum2scp/debian:latest' locally
latest: Pulling from minimum2scp/debian
f52bcf2d3e04: Pull complete 
Digest: sha256:d80d640d59e26c10ae97bf5af43481e4d1c16022dbd9bba516c2f648e67a40b1
Status: Downloaded newer image for minimum2scp/debian:latest
root@d28ce11291b1:/# apt-get update -qq
root@d28ce11291b1:/# apt-get install curl -s
Reading package lists... Done
Building dependency tree... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 curl : Depends: libcurl3 (= 7.58.0-2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
root@d28ce11291b1:/# apt-get install libcurl3 -s
Reading package lists... Done
Building dependency tree... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libcurl3 : Depends: libldap-2.4-2 (>= 2.4.7) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
root@d28ce11291b1:/# apt-get install libldap-2.4-2 -s 
Reading package lists... Done
Building dependency tree... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libldap-2.4-2 : Depends: libldap-common (>= 2.4.46+dfsg-1) but it is not installable
E: Unable to correct problems, you have held broken packages.
root@d28ce11291b1:/# apt-cache policy libldap-2.4-2 libldap-common
libldap-2.4-2:
  Installed: (none)
  Candidate: 2.4.46+dfsg-1
  Version table:
     2.4.46+dfsg-1 500
        500 http://ftp.jp.debian.org/debian sid/main amd64 Packages
libldap-common:
  Installed: (none)
  Candidate: (none)
  Version table:
```

And found a bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897898