### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -92,7 +92,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.16.1-1') }
+      it { should be_installed.with_version('1.16.1-2') }
     end
   end
 end


### PR DESCRIPTION
bundler 1.16.1-2 package was uploaded to sid
https://tracker.debian.org/news/954421/accepted-bundler-1161-2-source-into-unstable/