### PR TITLE
tdiary: updated workaround to install latest pushbullet_ruby and faraday

### DIFF
--- a/tdiary/build/home/debian/go/src/github.com/tdiary/tdiary-core/Gemfile.local
+++ b/tdiary/build/home/debian/go/src/github.com/tdiary/tdiary-core/Gemfile.local
@@ -11,5 +11,5 @@ gem "tdiary-style-rd",         :path => "../tdiary-style-rd"
 gem "tdiary-style-gfm",        :path => "../tdiary-style-gfm"
 
 ## workaround to resolve conflict `Bundler could not find compatible versions for gem "faraday"`
-gem "pushbullet_ruby", git: "https://github.com/minimum2scp/pushbullet_ruby", branch: "features/update-faraday-20180421"
+gem "pushbullet_ruby", git: "https://github.com/AlexandreKueny/pushbullet_ruby", branch: "master"
 


### PR DESCRIPTION
see also: #343, #341 