### PR TITLE
ruby: Fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -92,7 +92,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.16.1-2') }
+      it { should be_installed.with_version('1.16.1-3') }
     end
   end
 end


### PR DESCRIPTION
bundler 1.16.1-3 package was uploaded to sid
https://tracker.debian.org/news/974976/accepted-bundler-1161-3-source-into-unstable/