### PR TITLE
Removed unnecessary --cache-dir option 

### DIFF
--- a/debian-jessie/Rakefile
+++ b/debian-jessie/Rakefile
@@ -24,7 +24,7 @@ desc 'run mkimage.sh'
 task :mkimage  do
   tag_option = ENV['TAG'] ? "-t #{ENV['TAG']}" : ''
   debootstrap_options = %w[
-    --arch=amd64 --variant=minbase --components=main --include=iproute2,inetutils-ping --cache-dir=/var/tmp/mkimage-sh-cache-debootstrap
+    --arch=amd64 --variant=minbase --components=main --include=iproute2,inetutils-ping
   ]
   debootstrap_options << "--cache-dir=#{ENV['DEBOOTSTRAP_CACHE_DIR']}" if ENV['DEBOOTSTRAP_CACHE_DIR']
   debootstrap_options << 'jessie' << 'http://ftp.jp.debian.org/debian'


### PR DESCRIPTION
--cache-dir is added when DEBOOTSTRAP_CACHE_DIR is given.

see also: #363 