### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -92,7 +92,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.16.1-3') }
+      it { should be_installed.with_version('1.17.3-1') }
     end
   end
 end


### PR DESCRIPTION
bundler 1.17.3 package was uploaded into sid
https://tracker.debian.org/news/1026924/accepted-bundler-1173-1-source-into-unstable/