### PR TITLE
ruby, ruby-full, ruby-stretch: openssl 1.0 -> 1.1

### DIFF
--- a/ruby-full/README.md
+++ b/ruby-full/README.md
@@ -6,7 +6,7 @@
 # about minimum2scp/ruby-full image
 
  * based on minimum2scp/ruby (see https://github.com/minimum2scp/dockerfiles/tree/master/ruby)
- * ruby ruby ruby 2.3.8, ruby 2.4.5, ruby 2.5.3, ruby 2.6.1 is installed by rbenv
+ * ruby ruby ruby ruby 2.4.5, ruby 2.5.3, ruby 2.6.1 is installed by rbenv
  * ruby 2.5.3 is installed by debian package
 
 ## ssh login to container
@@ -55,7 +55,6 @@ rbenv gloabl (/opt/rbenv/version) is not defined, and some rubies are built.
 ```
 % docker run --rm -t minimum2scp/ruby-full:latest /bin/bash -l -c "rbenv versions"
 * system (set by /opt/rbenv/version)
-  2.3.8
   2.4.5
   2.5.3
   2.6.1

--- a/ruby-full/build/scripts/02-rbenv
+++ b/ruby-full/build/scripts/02-rbenv
@@ -12,5 +12,5 @@ bash -l -c "rbenv update"
 
 ## install pre-build binary (see https://github.com/minimum2scp/ruby-binary)
 curl -L --create-dirs -o /tmp/build/ruby-full/tmp/ruby-binary/install.sh https://raw.githubusercontent.com/minimum2scp/ruby-binary/master/install.sh
-sh /tmp/build/ruby-full/tmp/ruby-binary/install.sh -t v0.1.89
+sh /tmp/build/ruby-full/tmp/ruby-binary/install.sh -t v0.1.91
 

--- a/ruby-stretch/build/scripts/01-setup
+++ b/ruby-stretch/build/scripts/01-setup
@@ -6,7 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 ## packages: ruby2.3, and build tools
 packages="ruby ruby-dev rake"
-packages="$packages build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl1.0-dev libffi-dev libyaml-dev libgmp-dev"
+packages="$packages build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl-dev libffi-dev libyaml-dev libgmp-dev"
 packages="$packages gem2deb"
 
 ## install packages

--- a/ruby/build/scripts/01-setup
+++ b/ruby/build/scripts/01-setup
@@ -6,7 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 ## packages: ruby2.1, and build tools
 packages="ruby ruby-dev bundler rake pry"
-packages="$packages build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl1.0-dev libffi-dev libyaml-dev libgmp-dev"
+packages="$packages build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl-dev libffi-dev libyaml-dev libgmp-dev"
 packages="$packages gem2deb"
 
 ## install packages

--- a/spec/ruby-full/00base_spec.rb
+++ b/spec/ruby-full/00base_spec.rb
@@ -52,16 +52,6 @@ describe 'minimum2scp/ruby-full' do
         ],
         openssl_version: '1.1.1'
       },
-      {
-        ruby: '2.3.8',
-        desc: 'ruby 2.3.8p459 (2018-10-18 revision 65136) [x86_64-linux]',
-        rubygems_version: '3.0.2',
-        gems: [
-          {name: 'bundler', version: '2.0.1', default: '1.17.3'},
-          {name: 'pry'}
-        ],
-        openssl_version: '1.0.2'
-      },
     ].each do |v|
       describe command("rbenv versions --bare --skip-aliases") do
         let(:login_shell){ true }

--- a/spec/ruby-stretch/00base_spec.rb
+++ b/spec/ruby-stretch/00base_spec.rb
@@ -23,7 +23,7 @@ describe 'minimum2scp/ruby-stretch' do
 
     %w[
       ruby ruby-dev rake
-      build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libffi-dev libyaml-dev libgmp-dev
+      build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl-dev libffi-dev libyaml-dev libgmp-dev
       gem2deb
     ].each do |pkg|
       describe package(pkg) do
@@ -39,14 +39,10 @@ describe 'minimum2scp/ruby-stretch' do
       end
     end
 
-    %w[libssl1.0-dev libssl1.0.2 libssl1.1].each do |pkg|
+    %w[libssl1.1].each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end
-    end
-
-    describe package('libssl-dev') do
-      it { should_not be_installed }
     end
 
     describe file('/usr/bin/ruby') do

--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -23,7 +23,7 @@ describe 'minimum2scp/ruby' do
 
     %w[
       ruby ruby-dev bundler rake pry
-      build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libffi-dev libyaml-dev libgmp-dev
+      build-essential autoconf bison ca-certificates libgdbm-dev libncursesw5-dev libncurses5-dev libreadline-dev tcl-dev tk-dev zlib1g-dev libssl-dev libffi-dev libyaml-dev libgmp-dev
       gem2deb
     ].each do |pkg|
       describe package(pkg) do
@@ -31,14 +31,10 @@ describe 'minimum2scp/ruby' do
       end
     end
 
-    %w[libssl1.0-dev libssl1.0.2 libssl1.1].each do |pkg|
+    %w[libssl1.1].each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end
-    end
-
-    describe package('libssl-dev') do
-      it { should_not be_installed }
     end
 
     describe file('/usr/bin/ruby') do


### PR DESCRIPTION
openssl1.0 was removed from sid
https://tracker.debian.org/news/1033424/removed-102q-2-from-unstable/