### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.17.3-2') }
+      it { should be_installed.with_version('1.17.3-3') }
     end
   end
 end


### PR DESCRIPTION
bundler 1.17.3-3 was uploaded to sid
https://tracker.debian.org/news/1034690/accepted-bundler-1173-3-source-into-unstable/