### PR TITLE
baseimage: fixed to invoke post init scripts

### DIFF
--- a/baseimage/build/opt/init-wrapper/pre-init.d/99-install-post-init
+++ b/baseimage/build/opt/init-wrapper/pre-init.d/99-install-post-init
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-sed -i -e "s@^exit 0@run-parts --exit-on-error /opt/init-wrapper/post-init.d@" /etc/rc.local
+echo "run-parts --exit-on-error /opt/init-wrapper/post-init.d" >> /etc/rc.local
 if dpkg-query -s etckeeper 1>/dev/null 2>/dev/null; then
   etckeeper commit "rc.local: run /opt/init-wrapper/post-init.d/*" 1>/dev/null 2>/dev/null
 fi


### PR DESCRIPTION
Fix CI failures

<details>

```console
% bundle exec rspec spec/baseimage/00base_spec.rb 

minimum2scp/baseimage
  with env [APT_LINE=keep]

  (...snip...)

  with env [APT_LINE=keep, INSTALL_NGINX=yes]
    File "/opt/init-wrapper/post-init.d/07-nginx"
      example at ./spec/baseimage/00base_spec.rb:325 (FAILED - 1)
    File "/etc/apt/sources.list.d/nginx.list"
      example at ./spec/baseimage/00base_spec.rb:329 (FAILED - 2)
    File "/etc/apt/trusted.gpg.d/nginx.gpg"
      example at ./spec/baseimage/00base_spec.rb:333 (FAILED - 3)
    File "/etc/apt/preferences.d/nginx"
      example at ./spec/baseimage/00base_spec.rb:337 (FAILED - 4)
    Command "apt-cache policy"
      stdout
        example at ./spec/baseimage/00base_spec.rb:341 (FAILED - 5)
      stdout
        example at ./spec/baseimage/00base_spec.rb:346 (FAILED - 6)
    Package "nginx"
      example at ./spec/baseimage/00base_spec.rb:354 (FAILED - 7)
    File "/etc/nginx/conf.d/misc.conf"
      example at ./spec/baseimage/00base_spec.rb:358 (FAILED - 8)
    Service "nginx"
      example at ./spec/baseimage/00base_spec.rb:362 (FAILED - 9)
      example at ./spec/baseimage/00base_spec.rb:363 (FAILED - 10)

Failures:

  1) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/opt/init-wrapper/post-init.d/07-nginx" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  2) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/sources.list.d/nginx.list" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  3) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/trusted.gpg.d/nginx.gpg" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  4) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/preferences.d/nginx" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  5) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Command "apt-cache policy" stdout 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  6) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Command "apt-cache policy" stdout 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  7) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Package "nginx" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  8) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/nginx/conf.d/misc.conf" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  9) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Service "nginx" 
     On host `172.17.0.2'
     Failure/Error: sleep interval
     Timeout::Error:
       execution expired
       
     # ./spec/spec_helper.rb:62:in `sleep'
     # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
     # ./spec/spec_helper.rb:58:in `block in wait_container_port'
     # ./spec/spec_helper.rb:57:in `wait_container_port'
     # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

  10) minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Service "nginx" 
      On host `172.17.0.2'
      Failure/Error: sleep interval
      Timeout::Error:
        execution expired
        
      # ./spec/spec_helper.rb:62:in `sleep'
      # ./spec/spec_helper.rb:62:in `rescue in block in wait_container_port'
      # ./spec/spec_helper.rb:58:in `block in wait_container_port'
      # ./spec/spec_helper.rb:57:in `wait_container_port'
      # ./spec/baseimage/00base_spec.rb:317:in `block (3 levels) in <top (required)>'

Finished in 1 minute 41.91 seconds (files took 0.32038 seconds to load)
123 examples, 10 failures

Failed examples:

rspec ./spec/baseimage/00base_spec.rb:325 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/opt/init-wrapper/post-init.d/07-nginx" 
rspec ./spec/baseimage/00base_spec.rb:329 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/sources.list.d/nginx.list" 
rspec ./spec/baseimage/00base_spec.rb:333 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/trusted.gpg.d/nginx.gpg" 
rspec ./spec/baseimage/00base_spec.rb:337 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/apt/preferences.d/nginx" 
rspec ./spec/baseimage/00base_spec.rb:341 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Command "apt-cache policy" stdout 
rspec ./spec/baseimage/00base_spec.rb:346 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Command "apt-cache policy" stdout 
rspec ./spec/baseimage/00base_spec.rb:354 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Package "nginx" 
rspec ./spec/baseimage/00base_spec.rb:358 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] File "/etc/nginx/conf.d/misc.conf" 
rspec ./spec/baseimage/00base_spec.rb:362 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Service "nginx" 
rspec ./spec/baseimage/00base_spec.rb:363 # minimum2scp/baseimage with env [APT_LINE=keep, INSTALL_NGINX=yes] Service "nginx" 
```

</details>

Post init scripts (/opt/init-wrapper/post-init.d) was not invoked
because initscipts 2.95-1 changed /etc/rc.local file.

initscripts 2.93-8:

```shell
#!/bin/sh -e
#
# rc.local
#
# This script is executed at the end of each multiuser runlevel.
# Make sure that the script will "exit 0" on success or any other
# value on error.
#
# In order to enable or disable this script just change the execution
# bits.
#
# By default this script does nothing.

[ -d /etc/boot.d ] && run-parts /etc/boot.d

exit 0
```

initscripts 2.95-1:

```shell
#!/bin/sh -e
#
# rc.local
#
# This script is executed at the end of each multiuser runlevel.
# Make sure that the script will "exit 0" on success or any other
# value on error.
#
# In order to enable or disable this script just change the execution
# bits.

if test -d /etc/boot.d ; then
	run-parts /etc/boot.d
fi
```