### PR TITLE
tdiary: workaround for build error (downgrade faraday gem version)

### DIFF
--- a/tdiary/build/home/debian/go/src/github.com/tdiary/tdiary-core/Gemfile.local
+++ b/tdiary/build/home/debian/go/src/github.com/tdiary/tdiary-core/Gemfile.local
@@ -10,3 +10,4 @@ gem "tdiary-contrib",           :path => "../tdiary-contrib"
 gem "tdiary-style-rd",         :path => "../tdiary-style-rd"
 gem "tdiary-style-gfm",        :path => "../tdiary-style-gfm"
 
+gem "faraday", "< 1.0.0"

--- a/tdiary/build/user-scripts/setup-tdiary.sh
+++ b/tdiary/build/user-scripts/setup-tdiary.sh
@@ -38,6 +38,7 @@ bash -l -c "bundle install --path vendor/bundle --jobs=4"
 install -m 644 -p /tmp/build/tdiary/$GHQ_ROOT/github.com/tdiary/tdiary-core/Gemfile.local $GHQ_ROOT/github.com/tdiary/tdiary-core/Gemfile.local
 
 ## run bundle install again
+bash -l -c "bundle lock --update=faraday"
 bash -l -c "bundle install"
 bash -l -c "bundle clean"
 


### PR DESCRIPTION
```
+ bash -l -c bundle install
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 1.0.0)

  In Gemfile:
    octokit was resolved to 4.15.0, which depends on
      faraday (>= 0.9)

    tdiary-contrib was resolved to 5.1.0, which depends on
      pushbullet_ruby was resolved to 1.1.1, which depends on
        faraday (~> 0.9.0)

    octokit was resolved to 4.15.0, which depends on
      sawyer (~> 0.8.0, >= 0.5.3) was resolved to 0.8.2, which depends on
        faraday (> 0.8, < 2.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
run-parts: /tmp/build/tdiary/scripts/01-setup exited with return code 6
```