### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.17.3-3') }
+      it { should be_installed.with_version('2.1.4-1') }
     end
   end
 end


### PR DESCRIPTION
bundler 2.1.4-1 was uploaded to sid
https://tracker.debian.org/news/1099885/accepted-bundler-214-1-source-into-unstable/