### PR TITLE
ruby, ruby-full: Fixed spec, switched to ruby2.7 (ruby2.5-rm transition)

### DIFF
--- a/ruby-full/README.md
+++ b/ruby-full/README.md
@@ -5,7 +5,7 @@
 
  * based on minimum2scp/ruby (see https://github.com/minimum2scp/dockerfiles/tree/master/ruby)
  * ruby 2.4.9, ruby 2.5.7, ruby 2.6.5, ruby 2.7.0 is installed by rbenv
- * ruby 2.5.7 is installed by debian package
+ * ruby 2.7.0 is installed by debian package
 
 ## ssh login to container
 
@@ -58,7 +58,7 @@ rbenv gloabl (/opt/rbenv/version) is not defined, and some rubies are built.
   2.6.5
   2.7.0
 % docker run --rm -t minimum2scp/ruby-full:latest /bin/bash -l -c "ruby -v"
-ruby 2.5.7p206 (2019-10-01 revision 67816) [x86_64-linux-gnu]
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-gnu]
 ```
 
 

--- a/spec/ruby-full/00base_spec.rb
+++ b/spec/ruby-full/00base_spec.rb
@@ -107,14 +107,14 @@ describe 'minimum2scp/ruby-full' do
       end
     end
 
-    %w[ruby2.5 ruby2.5-dev].each do |pkg|
+    %w[ruby2.7 ruby2.7-dev].each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end
     end
 
-    describe command('ruby2.5 -v') do
-      its(:stdout) { should match a_string_starting_with('ruby 2.5.7p') }
+    describe command('ruby2.7 -v') do
+      its(:stdout) { should match a_string_starting_with('ruby 2.7.0p') }
     end
   end
 end

--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -39,11 +39,11 @@ describe 'minimum2scp/ruby' do
 
     describe file('/usr/bin/ruby') do
       it { should be_symlink }
-      it { should be_linked_to('ruby2.5') }
+      it { should be_linked_to('ruby2.7') }
     end
 
-    describe command('ruby2.5 -v') do
-      its(:stdout) { should match a_string_starting_with('ruby 2.5.7p') }
+    describe command('ruby2.7 -v') do
+      its(:stdout) { should match a_string_starting_with('ruby 2.7.0p') }
     end
 
     describe file('/opt/rbenv') do


### PR DESCRIPTION
ruby-defaults 1:2.7
https://lists.debian.org/debian-devel-changes/2020/03/msg01944.html

transition: ruby2.5-rm
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=953881
https://release.debian.org/transitions/html/ruby2.5-rm.html