### PR TITLE
norikra: jruby 9.2.11.1

### DIFF
--- a/norikra/build/scripts/02-rbenv
+++ b/norikra/build/scripts/02-rbenv
@@ -10,9 +10,9 @@ jruby_version=9.2.11.1
 bash -l -c "rbenv install jruby-${jruby_version}"
 
 ## install norikra with JRuby
-bash -l -c "RBENV_VERSION=jruby-${jruby_version} gem install norikra"
+bash -l -c "RBENV_VERSION=jruby-${jruby_version} gem install norikra -N"
 
 ## install norikura-client with CRuby
-bash -l -c "RBENV_VERSION=system gem install norikra-client"
+bash -l -c "RBENV_VERSION=system gem install norikra-client -N"
 
 

--- a/norikra/build/scripts/02-rbenv
+++ b/norikra/build/scripts/02-rbenv
@@ -4,7 +4,7 @@ set -e
 set -x
 export DEBIAN_FRONTEND=noninteractive
 
-jruby_version=9.1.5.0
+jruby_version=9.2.11.1
 
 ## install jruby by rbenv
 bash -l -c "rbenv install jruby-${jruby_version}"

--- a/spec/norikra/00base_spec.rb
+++ b/spec/norikra/00base_spec.rb
@@ -22,7 +22,7 @@ describe 'minimum2scp/norikra' do
     end
 
     describe package('norikra') do
-      let(:path){ '/opt/rbenv/versions/jruby-9.1.5.0/bin:$PATH' }
+      let(:path){ '/opt/rbenv/versions/jruby-9.2.11.1/bin:$PATH' }
       it { should be_installed.by('gem') }
     end
   end


### PR DESCRIPTION
Fixes build error:

```
+ bash -l -c RBENV_VERSION=jruby-9.1.5.0 gem install norikra
unsupported Java version "11", defaulting to 1.7
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.util.io.FilenoUtil to method sun.nio.ch.SelChImpl.getFD()
WARNING: Please consider reporting this to the maintainers of org.jruby.util.io.FilenoUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
io/console on JRuby shells out to stty for most operations
Successfully installed erubis-2.7.0
Successfully installed rack-2.2.3
Successfully installed tilt-2.0.10
Successfully installed rack-protection-2.0.8.1
Successfully installed ruby2_keywords-0.0.2
Successfully installed mustermann-1.1.1
Successfully installed sinatra-2.0.8.1
Successfully installed backports-3.18.0
Successfully installed multi_json-1.14.1
Successfully installed sinatra-contrib-2.0.8.1
Successfully installed ltsv-0.1.2
Successfully installed thor-1.0.1
Successfully installed httpclient-2.8.3
Successfully installed hitimes-2.0.0
Successfully installed timers-4.0.4
Successfully installed celluloid-0.16.0
Successfully installed msgpack-1.3.3-java
Successfully installed msgpack-rpc-over-http-0.1.0
Successfully installed norikra-client-1.4.0
ERROR:  Error installing norikra:
	childprocess requires Ruby version >= 2.4.0.
run-parts: /tmp/build/norikra/scripts/02-rbenv exited with return code 1
```