### PR TITLE
Fixed ruby-buster spec

### DIFF
--- a/spec/ruby-buster/00base_spec.rb
+++ b/spec/ruby-buster/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('1.17.3-3') }
+      it { should be_installed.with_version('1.17.3-3+deb10u1') }
     end
   end
 end


### PR DESCRIPTION
bundler 1.17.3-3+deb10u1 is uploaded
https://tracker.debian.org/news/1146126/accepted-bundler-1173-3deb10u1-source-into-proposed-updates-stable-new-proposed-updates/