### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('2.2.0~rc.2-5') }
+      it { should be_installed.with_version('2.2.4-1') }
     end
   end
 end


### PR DESCRIPTION
bundler 2.2.4-1 (and rubygems 3.2.4-1) was uploaded to sid
https://tracker.debian.org/news/1215845/accepted-rubygems-324-1-source-into-unstable/
