### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('2.2.4-1') }
+      it { should be_installed.with_version('2.2.5-2') }
     end
   end
 end


### PR DESCRIPTION
bundler 2.2.5-2 (and rubygems 3.2.5-2) was uploaded to sid
https://tracker.debian.org/news/1219226/accepted-rubygems-325-2-source-into-unstable/
