### PR TITLE
Revert "rails6: fixed build error (mimemagic gem depends shared-mime-info package)"

### DIFF
--- a/rails6/build/scripts/01-setup
+++ b/rails6/build/scripts/01-setup
@@ -8,7 +8,6 @@ export DEBIAN_FRONTEND=noninteractive
 packages="sqlite3 libsqlite3-dev"
 packages="$packages mysql-client libmysqlclient-dev"
 packages="$packages postgresql-client libpq-dev"
-packages="$packages shared-mime-info"
 
 ## install packages
 apt-get install --install-recommends -y ${packages}


### PR DESCRIPTION
Reverts minimum2scp/dockerfiles#777

https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/