### PR TITLE
baseimage, baseimage-buster, baseimage-stretch: replaced apt-key command in nginx installer script

### DIFF
--- a/baseimage-buster/build/opt/custom-installers/nginx/install.sh
+++ b/baseimage-buster/build/opt/custom-installers/nginx/install.sh
@@ -9,14 +9,14 @@ nginx_version="1.20.0-1~buster"
 apt-get install -y --no-install-recommends gnupg
 
 ## install apt key
-curl -sSf http://nginx.org/keys/nginx_signing.key | apt-key --keyring /etc/apt/trusted.gpg.d/nginx.gpg add -
+curl -sSf http://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx.gpg
 
 ## add apt-line
 (
-  echo "deb     http://nginx.org/packages/debian/ buster nginx"
-  echo "deb-src http://nginx.org/packages/debian/ buster nginx"
-  echo "deb     http://nginx.org/packages/mainline/debian/ buster nginx"
-  echo "deb-src http://nginx.org/packages/mainline/debian/ buster nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ buster nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ buster nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ buster nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ buster nginx"
 ) | tee /etc/apt/sources.list.d/nginx.list
 
 ## add apt-preferences

--- a/baseimage-stretch/build/opt/custom-installers/nginx/install.sh
+++ b/baseimage-stretch/build/opt/custom-installers/nginx/install.sh
@@ -9,14 +9,14 @@ nginx_version="1.19.6-1~stretch"
 apt-get install -y --no-install-recommends gnupg
 
 ## install apt key
-curl -sSf http://nginx.org/keys/nginx_signing.key | apt-key --keyring /etc/apt/trusted.gpg.d/nginx.gpg add -
+curl -sSf http://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx.gpg
 
 ## add apt-line
 (
-  echo "deb     http://nginx.org/packages/debian/ stretch nginx"
-  echo "deb-src http://nginx.org/packages/debian/ stretch nginx"
-  echo "deb     http://nginx.org/packages/mainline/debian/ stretch nginx"
-  echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ stretch nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ stretch nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ stretch nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ stretch nginx"
 ) | tee /etc/apt/sources.list.d/nginx.list
 
 ## add apt-preferences

--- a/baseimage/build/opt/custom-installers/nginx/install.sh
+++ b/baseimage/build/opt/custom-installers/nginx/install.sh
@@ -9,14 +9,14 @@ nginx_version="1.20.0-1~buster"
 apt-get install -y --no-install-recommends gnupg
 
 ## install apt key
-curl -sSf http://nginx.org/keys/nginx_signing.key | apt-key --keyring /etc/apt/trusted.gpg.d/nginx.gpg add -
+curl -sSf http://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx.gpg
 
 ## add apt-line
 (
-  echo "deb     http://nginx.org/packages/debian/ buster nginx"
-  echo "deb-src http://nginx.org/packages/debian/ buster nginx"
-  echo "deb     http://nginx.org/packages/mainline/debian/ buster nginx"
-  echo "deb-src http://nginx.org/packages/mainline/debian/ buster nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ buster nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/debian/ buster nginx"
+  echo "deb     [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ buster nginx"
+  echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ buster nginx"
 ) | tee /etc/apt/sources.list.d/nginx.list
 
 ## add apt-preferences

--- a/spec/baseimage-buster/00base_spec.rb
+++ b/spec/baseimage-buster/00base_spec.rb
@@ -329,7 +329,7 @@ describe 'minimum2scp/baseimage-buster' do
       it { should be_file }
     end
 
-    describe file('/etc/apt/trusted.gpg.d/nginx.gpg') do
+    describe file('/usr/share/keyrings/nginx.gpg') do
       it { should be_file }
     end
 

--- a/spec/baseimage-stretch/00base_spec.rb
+++ b/spec/baseimage-stretch/00base_spec.rb
@@ -331,7 +331,7 @@ describe 'minimum2scp/baseimage-stretch' do
       it { should be_file }
     end
 
-    describe file('/etc/apt/trusted.gpg.d/nginx.gpg') do
+    describe file('/usr/share/keyrings/nginx.gpg') do
       it { should be_file }
     end
 

--- a/spec/baseimage/00base_spec.rb
+++ b/spec/baseimage/00base_spec.rb
@@ -325,7 +325,7 @@ describe 'minimum2scp/baseimage' do
       it { should be_file }
     end
 
-    describe file('/etc/apt/trusted.gpg.d/nginx.gpg') do
+    describe file('/usr/share/keyrings/nginx.gpg') do
       it { should be_file }
     end
 


### PR DESCRIPTION
apt-key is deprecated.
see also: https://wiki.debian.org/DebianRepository/UseThirdParty