### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -88,7 +88,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('2.2.5-2') }
+      it { should be_installed.with_version('2.2.27-1') }
     end
   end
 end


### PR DESCRIPTION
rubygems 3.2.27-1 and bundler 2.2.27-1 was uploaded to sid
https://tracker.debian.org/news/1260947/accepted-rubygems-3227-1-source-into-unstable/
