### PR TITLE
baseimage: [workaround] skipped tests for rsyslog service

### DIFF
--- a/baseimage/README.md
+++ b/baseimage/README.md
@@ -4,7 +4,7 @@
  * Runs [/opt/init-wrapper/sbin/init](https://github.com/minimum2scp/dockerfiles/blob/master/baseimage/build/opt/init-wrapper/sbin/init) by default
    * /opt/init-wrapper/sbin/init invokes all scripts in /opt/init-wrapper/pre-init.d (using run-parts), and exec /sbin/init
    * /sbin/init is replaced by sysvinit-core package
-   * /sbin/init invokes sshd, rsyslogd, cron daemons
+   * /sbin/init invokes sshd, ~rsyslogd~, cron daemons
    * /etc/rc.local invokes all scripts in /opt/init-wrapper/post-init.d (using run-parts)
  * ja_JP.UTF-8 locale supported. (default locale is C)
  * timezone is Asia/Tokyo
@@ -40,15 +40,14 @@ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 debian@l
 ## processes
 
 ```
-UID        PID  PPID  C STIME TTY      STAT   TIME CMD
-root         1     0  0 01:52 ?        Ss     0:00 init [2]
-root        37     1  0 01:52 ?        Ssl    0:00 /usr/sbin/rsyslogd
-root        62     1  0 01:52 ?        Ss     0:00 /usr/sbin/cron
-root        73     1  0 01:52 ?        Ss     0:00 /usr/sbin/sshd
-root        80    73  0 01:52 ?        Ss     0:00  \_ sshd: debian [priv]
-debian      82    80  0 01:52 ?        S      0:00      \_ sshd: debian@pts/0
-debian      83    82  0 01:52 pts/0    Ss     0:00          \_ -bash
-debian      89    83  0 01:52 pts/0    R+     0:00              \_ ps -ef fww
+UID          PID    PPID  C STIME TTY      STAT   TIME CMD
+root           1       0  0 02:17 ?        Ss     0:00 init [2]
+root         527       1  0 02:17 ?        Ss     0:00 /usr/sbin/cron
+root         536       1  0 02:17 ?        Ss     0:00 sshd: /usr/sbin/sshd [listener] 0 of 10-100 startups
+root        1193     536  1 02:33 ?        Ss     0:00  \_ sshd: debian [priv]
+debian      1199    1193  0 02:33 ?        S      0:00      \_ sshd: debian@pts/0
+debian      1200    1199  0 02:33 pts/0    Ss     0:00          \_ -bash
+debian      1203    1200  0 02:33 pts/0    R+     0:00              \_ ps -ef fww
 ```
 
 ## ports

--- a/baseimage/README.md.erb
+++ b/baseimage/README.md.erb
@@ -4,7 +4,7 @@
  * Runs [/opt/init-wrapper/sbin/init](https://github.com/minimum2scp/dockerfiles/blob/master/baseimage/build/opt/init-wrapper/sbin/init) by default
    * /opt/init-wrapper/sbin/init invokes all scripts in /opt/init-wrapper/pre-init.d (using run-parts), and exec /sbin/init
    * /sbin/init is replaced by sysvinit-core package
-   * /sbin/init invokes sshd, rsyslogd, cron daemons
+   * /sbin/init invokes sshd, ~rsyslogd~, cron daemons
    * /etc/rc.local invokes all scripts in /opt/init-wrapper/post-init.d (using run-parts)
  * ja_JP.UTF-8 locale supported. (default locale is C)
  * timezone is Asia/Tokyo
@@ -40,15 +40,14 @@ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 debian@l
 ## processes
 
 ```
-UID        PID  PPID  C STIME TTY      STAT   TIME CMD
-root         1     0  0 01:52 ?        Ss     0:00 init [2]
-root        37     1  0 01:52 ?        Ssl    0:00 /usr/sbin/rsyslogd
-root        62     1  0 01:52 ?        Ss     0:00 /usr/sbin/cron
-root        73     1  0 01:52 ?        Ss     0:00 /usr/sbin/sshd
-root        80    73  0 01:52 ?        Ss     0:00  \_ sshd: debian [priv]
-debian      82    80  0 01:52 ?        S      0:00      \_ sshd: debian@pts/0
-debian      83    82  0 01:52 pts/0    Ss     0:00          \_ -bash
-debian      89    83  0 01:52 pts/0    R+     0:00              \_ ps -ef fww
+UID          PID    PPID  C STIME TTY      STAT   TIME CMD
+root           1       0  0 02:17 ?        Ss     0:00 init [2]
+root         527       1  0 02:17 ?        Ss     0:00 /usr/sbin/cron
+root         536       1  0 02:17 ?        Ss     0:00 sshd: /usr/sbin/sshd [listener] 0 of 10-100 startups
+root        1193     536  1 02:33 ?        Ss     0:00  \_ sshd: debian [priv]
+debian      1199    1193  0 02:33 ?        S      0:00      \_ sshd: debian@pts/0
+debian      1200    1199  0 02:33 pts/0    Ss     0:00          \_ -bash
+debian      1203    1200  0 02:33 pts/0    R+     0:00              \_ ps -ef fww
 ```
 
 ## ports

--- a/spec/baseimage/00base_spec.rb
+++ b/spec/baseimage/00base_spec.rb
@@ -126,10 +126,21 @@ describe 'minimum2scp/baseimage' do
       it { should have_login_shell '/bin/bash' }
     end
 
-    %w[ssh cron rsyslog].each do |svc|
+    %w[ssh cron].each do |svc|
       describe service(svc) do
         it { should be_enabled }
         it { should be_running }
+      end
+    end
+
+    describe service('rsyslog') do
+      it do
+        pending 'missing sysv init script'
+        should be_enabled
+      end
+      it do
+        pending 'missing sysv init script'
+        should be_running
       end
     end
 


### PR DESCRIPTION
`rspec spec/baseimage/00base_spec.rb`:

```
Failures:

  1) minimum2scp/baseimage with env [APT_LINE=keep] Service "rsyslog" is expected to be enabled
     On host `172.17.0.2'
     Failure/Error: it { should be_enabled }
       expected Service "rsyslog" to be enabled
       sudo -p 'Password: ' /bin/sh -c ls\ /etc/rc3.d/\ \|\ grep\ --\ \'\^S..rsyslog\$\'\ \|\|\ grep\ \'\^\ \*start\ on\'\ /etc/init/rsyslog.conf

     # ./spec/baseimage/00base_spec.rb:131:in `block (5 levels) in <top (required)>'

  2) minimum2scp/baseimage with env [APT_LINE=keep] Service "rsyslog" is expected to be running
     On host `172.17.0.2'
     Failure/Error: it { should be_running }
       expected Service "rsyslog" to be running
       sudo -p 'Password: ' /bin/sh -c ps\ aux\ \|\ grep\ -w\ --\ rsyslog\ \|\ grep\ -qv\ grep

     # ./spec/baseimage/00base_spec.rb:132:in `block (5 levels) in <top (required)>'
```

See also:

- https://tracker.debian.org/news/1274713/accepted-rsyslog-821100-2-source-into-unstable/
- https://salsa.debian.org/debian/rsyslog/-/commit/f8bd960be037300f27b54b4d2270a07404f927d5