### PR TITLE
baseimage: install orphan-sysvinit-scripts package to run rsyslog with sysv init

### DIFF
--- a/baseimage/build/scripts/01-setup
+++ b/baseimage/build/scripts/01-setup
@@ -12,7 +12,7 @@ packages="$packages etckeeper"
 packages="$packages locales tzdata"
 packages="$packages localepurge"
 packages="$packages sysvinit-core systemd-sysv- systemd-"
-packages="$packages openssh-server rsyslog cron"
+packages="$packages openssh-server rsyslog cron orphan-sysvinit-scripts"
 
 ##
 ## install packages


### PR DESCRIPTION
see also:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998340
- https://tracker.debian.org/news/1273532/accepted-orphan-sysvinit-scripts-008-source-into-unstable/
- https://tracker.debian.org/news/1274713/accepted-rsyslog-821100-2-source-into-unstable/

close #887 