### PR TITLE
Addressed ERB.new arguments warnings

### DIFF
--- a/baseimage-bullseye/Rakefile
+++ b/baseimage-bullseye/Rakefile
@@ -30,7 +30,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/baseimage-buster/Rakefile
+++ b/baseimage-buster/Rakefile
@@ -30,7 +30,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/baseimage-stretch/Rakefile
+++ b/baseimage-stretch/Rakefile
@@ -30,7 +30,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/baseimage/Rakefile
+++ b/baseimage/Rakefile
@@ -30,7 +30,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/debian-bullseye/Rakefile
+++ b/debian-bullseye/Rakefile
@@ -65,7 +65,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/debian-buster/Rakefile
+++ b/debian-buster/Rakefile
@@ -65,7 +65,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/debian-stretch/Rakefile
+++ b/debian-stretch/Rakefile
@@ -65,7 +65,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 

--- a/debian/Rakefile
+++ b/debian/Rakefile
@@ -65,7 +65,7 @@ desc 'update README.md'
 file 'README.md' => ['README.md.erb', 'debian-packages.json'] do |t|
   packages = JSON.parse(File.read('debian-packages.json'))
   File.open(t.name, "w") do |fh|
-    fh << ERB.new(File.read('README.md.erb'), nil, '-').result(binding)
+    fh << ERB.new(File.read('README.md.erb'), trim_mode: '-').result(binding)
   end
 end
 


### PR DESCRIPTION
- "warning: Passing safe_level with the 2nd argument of ERB.new is
  deprecated. Do not use it, and specify other arguments as keyword
  arguments."
- "warning: Passing trim_mode with the 3rd argument of ERB.new is
  deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
  instead."
