### PR TITLE
baseimage: Rebuild nginx package against libssl3 (workaround)

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -1,10 +1,19 @@
-FROM minimum2scp/debian:latest
+# syntax=docker/dockerfile:1
+FROM minimum2scp/debian:latest AS baseimage
 LABEL maintainer="YAMADA Tsuyoshi <tyamada@minimum2scp.org>"
 
 COPY build /tmp/build/baseimage
 RUN run-parts --report --exit-on-error /tmp/build/baseimage/scripts && rm -rfv /tmp/build
-EXPOSE 22
 
+FROM baseimage AS nginx_builder
+COPY build /tmp/build/baseimage
+WORKDIR /var/tmp/nginx
+RUN /tmp/build/baseimage/build_nginx
+
+FROM baseimage
+COPY --from=nginx_builder /var/tmp/nginx /var/tmp/nginx
+
+EXPOSE 22
 ENTRYPOINT ["/opt/init-wrapper/sbin/entrypoint.sh"]
 CMD ["/sbin/init"]
 

--- a/baseimage/build/build_nginx
+++ b/baseimage/build/build_nginx
@@ -3,7 +3,8 @@
 set -e
 set -x
 
-nginx_version="1.22.1-1~bullseye"
+nginx_version="1.22.1"
+nginx_pkg_version="${nginx_version}-1~bullseye"
 
 ## install gnupg
 apt-get install -y --no-install-recommends gnupg
@@ -20,28 +21,19 @@ curl -sSf http://nginx.org/keys/nginx_signing.key | \
   echo "deb-src [signed-by=/usr/share/keyrings/nginx.gpg] http://nginx.org/packages/mainline/debian/ bullseye nginx"
 ) | tee /etc/apt/sources.list.d/nginx.list
 
-## add apt-preferences
-cat <<EOS >/etc/apt/preferences.d/nginx
-Package: *
-Pin: release o=nginx, l=nginx
-Pin-Priority: 600
-EOS
-
-## etckeeper
-if etckeeper unclean 1>/dev/null 2>/dev/null; then
-  etckeeper commit "apt: added apt-line, apt-preferences for nginx"
-fi
-
-## install nginx
+## install nginx build-dep
 apt-get update
-# apt-get install -y --no-install-recommends nginx=${nginx_version}
-apt install -y --no-install-recommends /var/tmp/nginx/nginx_${nginx_version}_amd64.deb
+apt-get install -y --no-install-recommends build-essential fakeroot devscripts
+apt-get build-dep -y --no-install-recommends nginx=${nginx_pkg_version}
 
-## configure nginx
-install -m 644 -o root -g root -p /opt/custom-installers/nginx/etc/nginx/conf.d/misc.conf /etc/nginx/conf.d/misc.conf
-if etckeeper unclean 1>/dev/null 2>/dev/null; then
-  etckeeper commit "nginx: add conf.d/misc.conf"
-fi
+## download nginx source code
+apt-get source nginx=${nginx_pkg_version}
 
-## start nginx
-service nginx start
+## rebuild nginx
+cd nginx-${nginx_version}
+debuild -b -uc -us
+
+## cleanup
+cd ..
+rm -rf nginx-${nginx_version}
+


### PR DESCRIPTION


<details>

```console
debian@8f07b165b2ec:~$ sudo /opt/custom-installers/nginx/install.sh 
(...snip...)
+ apt-get install -y --no-install-recommends nginx=1.22.1-1~bullseye
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 nginx : Depends: libssl1.1 (>= 1.1.1) but it is not installable
E: Unable to correct problems, you have held broken packages.
```

</details>