### PR TITLE
baseimage, tdiary: nginx 1.22.1-9

### DIFF
--- a/spec/baseimage/00base_spec.rb
+++ b/spec/baseimage/00base_spec.rb
@@ -360,7 +360,7 @@ describe 'minimum2scp/baseimage' do
         pending 'Switched nginx package to debian.org ones'
         should be_installed.with_version('1.22.1-1~bullseye')
       }
-      it { should be_installed.with_version('1.22.1-7') }
+      it { should be_installed.with_version('1.22.1-9') }
     end
 
     describe file('/etc/nginx/conf.d/misc.conf') do

--- a/spec/tdiary/00base_spec.rb
+++ b/spec/tdiary/00base_spec.rb
@@ -100,7 +100,7 @@ describe 'minimum2scp/tdiary' do
           pending 'Switched nginx package to debian.org ones'
           should be_installed.with_version('1.22.1-1~bullseye')
         }
-        it { should be_installed.with_version('1.22.1-7') }
+        it { should be_installed.with_version('1.22.1-9') }
       end
 
       describe file('/etc/nginx/nginx.conf') do


### PR DESCRIPTION
https://tracker.debian.org/news/1426966/accepted-nginx-1221-8-source-into-unstable/
https://tracker.debian.org/news/1426987/accepted-nginx-1221-9-source-into-unstable/