### PR TITLE
baseimage, tdiary: nginx 1.24.0-1

### DIFF
--- a/spec/baseimage/00base_spec.rb
+++ b/spec/baseimage/00base_spec.rb
@@ -380,7 +380,7 @@ describe 'minimum2scp/baseimage' do
         pending 'Switched nginx package to debian.org ones'
         should be_installed.with_version('1.22.1-1~bullseye')
       }
-      it { should be_installed.with_version('1.22.1-9') }
+      it { should be_installed.with_version('1.24.0-1') }
     end
 
     describe file('/etc/nginx/conf.d/misc.conf') do

--- a/spec/tdiary/00base_spec.rb
+++ b/spec/tdiary/00base_spec.rb
@@ -99,7 +99,7 @@ describe 'minimum2scp/tdiary' do
           pending 'Switched nginx package to debian.org ones'
           should be_installed.with_version('1.22.1-1~bullseye')
         }
-        it { should be_installed.with_version('1.22.1-9') }
+        it { should be_installed.with_version('1.24.0-1') }
       end
 
       describe file('/etc/nginx/nginx.conf') do


### PR DESCRIPTION
https://tracker.debian.org/news/1440028/accepted-nginx-1240-1-source-into-unstable/