### PR TITLE
ruby: fixed spec

### DIFF
--- a/spec/ruby/00base_spec.rb
+++ b/spec/ruby/00base_spec.rb
@@ -87,7 +87,7 @@ describe 'minimum2scp/ruby' do
     end
 
     describe package('bundler') do
-      it { should be_installed.with_version('2.3.15-2') }
+      it { should be_installed.with_version('2.4.20-1') }
     end
   end
 end


### PR DESCRIPTION
rubygems 3.4.20-1, bundler 2.4.20-1
https://tracker.debian.org/news/1472189/accepted-rubygems-3420-1-source-into-unstable/